### PR TITLE
C.MVA01S07 compiler support

### DIFF
--- a/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -32,6 +32,7 @@ add_llvm_target(RISCVCodeGen
   RISCVLegalizerInfo.cpp
   RISCVMCInstLower.cpp
   RISCVMergeBaseOffset.cpp
+  RISCVMoveOptimizer.cpp
   RISCVRegisterBankInfo.cpp
   RISCVRegisterInfo.cpp
   RISCVSubtarget.cpp

--- a/llvm/lib/Target/RISCV/RISCV.h
+++ b/llvm/lib/Target/RISCV/RISCV.h
@@ -52,6 +52,9 @@ void initializeRISCVCleanupVSETVLIPass(PassRegistry &);
 FunctionPass *createRISCVZceInstOptPass();
 void initializeRISCVZceInstOptPass(PassRegistry &);
 
+FunctionPass *createRISCVMoveOptimizationPass();
+void initializeRISCVMoveOptPass(PassRegistry&);
+
 InstructionSelector *createRISCVInstructionSelector(const RISCVTargetMachine &,
                                                     RISCVSubtarget &,
                                                     RISCVRegisterBankInfo &);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -821,6 +821,43 @@ bool RISCVInstrInfo::isAsCheapAsAMove(const MachineInstr &MI) const {
 }
 
 Optional<DestSourcePair>
+RISCVInstrInfo::getCMovReg(MachineInstr &MI) const{
+  switch(MI.getOpcode()) {
+  default:
+    return None;
+  case RISCV::ADD:{
+    MachineOperand *Op0 = &MI.getOperand(0);
+    MachineOperand *Op1 = &MI.getOperand(1);
+    MachineOperand *Op2 = &MI.getOperand(2);
+
+    if (!Op0->isReg() || !Op1->isReg() || !Op2->isReg() || 
+        (Op0->getReg() == RISCV::X0)) 
+      return None;
+
+    if ((Op1->getReg() == RISCV::X0) && (Op2->getReg() != RISCV::X0))
+      return DestSourcePair{*Op0, *Op2};
+
+    if ((Op1->getReg() != RISCV::X0) && (Op2->getReg() == RISCV::X0))
+      return DestSourcePair{*Op0, *Op1};
+
+    return None;
+  }
+  case RISCV::ADDI:{
+    MachineOperand *Op0 = &MI.getOperand(0);
+    MachineOperand *Op1 = &MI.getOperand(1);
+    MachineOperand *Op2 = &MI.getOperand(2);
+    if (Op0->isReg() && Op1->isReg() && Op2->isImm() &&
+       (Op0->getReg() != RISCV::X0) &&
+       (Op1->getReg() != RISCV::X0) && 
+       (Op2->getImm() == 0))
+      return DestSourcePair{*Op0, *Op1};
+    
+    return None;
+  }
+  }
+}
+
+Optional<DestSourcePair>
 RISCVInstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
   if (MI.isMoveReg())
     return DestSourcePair{MI.getOperand(0), MI.getOperand(1)};
@@ -1434,3 +1471,5 @@ RISCVInstrInfo::isRVVSpillForZvlsseg(unsigned Opcode) const {
     return std::make_pair(8u, 1u);
   }
 }
+
+

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -86,6 +86,10 @@ public:
 
   bool isAsCheapAsAMove(const MachineInstr &MI) const override;
 
+  // If the instruction can be transformed into C.MOV, return register
+  // pair. Return none otherwise.
+  Optional<DestSourcePair> getCMovReg(MachineInstr &MI) const;
+
   Optional<DestSourcePair>
   isCopyInstrImpl(const MachineInstr &MI) const override;
 
@@ -149,6 +153,7 @@ public:
 
   Optional<std::pair<unsigned, unsigned>>
   isRVVSpillForZvlsseg(unsigned Opcode) const;
+ 
 
 protected:
   const RISCVSubtarget &STI;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZce.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZce.td
@@ -322,10 +322,10 @@ def C_MUL     : RVZceArith_rr<0b100111, 0b10, 0b01, "c.mul">, Sched<[]>;
 }
 
 // 6.3 C.MVA01S07
-let Predicates = [HasStdExtZcea],
+let Predicates = [HasStdExtZcea], Defs = [X10, X11],
     hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-def C_MVA01S07 : RVInst16CA<0b100111, 0b11, 0b01, (outs SR07:$rs1, SR07:$rs2),
-                            (ins), "c.mva01s07", "$rs1, $rs2">,
+def C_MVA01S07 : RVInst16CA<0b100111, 0b11, 0b01, (outs),
+                            (ins SR07:$rs1, SR07:$rs2), "c.mva01s07", "$rs1, $rs2">,
                 Sched<[]>;
 
 // 6.4 MULI

--- a/llvm/lib/Target/RISCV/RISCVMoveOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVMoveOptimizer.cpp
@@ -1,0 +1,187 @@
+//===- RISCVMoveOptimizer.cpp - RISCV move opt. pass -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains a pass that performs move related peephole
+// optimizations. This pass should be run after register allocation.
+//
+//===----------------------------------------------------------------------===//
+
+
+#include "RISCVInstrInfo.h"
+#include "RISCVMachineFunctionInfo.h"
+#include "RISCVSubtarget.h"
+
+using namespace llvm;
+
+#define RISCV_MOVE_OPT_NAME "RISC-V Zce move merging pass"
+
+namespace{
+struct RISCVMoveOpt : public MachineFunctionPass{
+    static char ID;
+
+    RISCVMoveOpt(): MachineFunctionPass(ID) {
+      initializeRISCVMoveOptPass(*PassRegistry::getPassRegistry());
+    }
+
+    const RISCVInstrInfo *TII;
+    const TargetRegisterInfo *TRI;
+    const RISCVSubtarget *Subtarget;
+
+    // Track which register units have been modified and used.
+    LiveRegUnits ModifiedRegUnits, UsedRegUnits;
+    
+    // Merge the two instructions indicated into a single pair instruction.
+    MachineBasicBlock::iterator
+    mergePairedInsns(MachineBasicBlock::iterator I,
+                     MachineBasicBlock::iterator Paired);
+
+    //Look for C.MV instruction that can be combined with 
+    //the given instruction into C.MVA01S07. Return the matching instruction if
+    //one exists.
+    MachineBasicBlock::iterator findMatchingInst(MachineBasicBlock::iterator &MBBI);
+    bool MovOpt(MachineBasicBlock &MBB);
+    bool runOnMachineFunction(MachineFunction &Fn) override;
+
+    StringRef getPassName() const override { return RISCV_MOVE_OPT_NAME; }
+};
+
+char RISCVMoveOpt::ID = 0;
+
+} //end of anonymous namespace
+
+INITIALIZE_PASS(RISCVMoveOpt, "riscv-mov-opt", RISCV_MOVE_OPT_NAME, false,
+                false)
+
+// Check if registers meet C.MVA01S07 constraints. 
+static bool isCandidateToMerge(DestSourcePair &RegPair){
+  Register Destination = RegPair.Destination->getReg();
+  Register Source = RegPair.Source->getReg();
+  
+  // If destination is not a0 or a1.
+  if (Destination != RISCV::X10 && 
+      Destination != RISCV::X11)
+    return false;
+  
+  if (Source == RISCV::X8 || Source == RISCV::X9 ||
+     (Source >= RISCV::X18 && Source <= RISCV::X23))
+     return true;
+  else 
+     return false;
+}
+
+MachineBasicBlock::iterator
+RISCVMoveOpt::mergePairedInsns(MachineBasicBlock::iterator I,
+                               MachineBasicBlock::iterator Paired){
+  MachineBasicBlock::iterator E = I->getParent()->end();
+  MachineBasicBlock::iterator NextI = next_nodbg(I, E);
+  DestSourcePair FirstPair = TII->getCMovReg(*I).getValue();
+  DestSourcePair PairedRegs = TII->getCMovReg(*Paired).getValue();
+
+  if (NextI == Paired)
+    NextI = next_nodbg(NextI, E);
+  DebugLoc DL = I->getDebugLoc();
+  MachineInstrBuilder MIB;
+  MIB = BuildMI(*I->getParent(), I, DL, TII->get(RISCV::C_MVA01S07))
+            .add(*FirstPair.Source)
+            .add(*PairedRegs.Source);
+  I->eraseFromParent();
+  Paired->eraseFromParent();
+  return NextI;
+}
+                      
+MachineBasicBlock::iterator
+RISCVMoveOpt::findMatchingInst(MachineBasicBlock::iterator &MBBI){
+  MachineBasicBlock::iterator E = MBBI->getParent()->end();
+  DestSourcePair FirstPair = TII->getCMovReg(*MBBI).getValue();
+
+  // Track which register units have been modified and used between the first
+  // insn and the second insn.
+  ModifiedRegUnits.clear();
+  UsedRegUnits.clear();
+  
+  for (MachineBasicBlock::iterator I = next_nodbg(MBBI,E); I != E; 
+        I = next_nodbg(I, E)){
+    
+    MachineInstr &MI = *I;
+    
+    if (auto SecondPair = TII->getCMovReg(MI)){
+      Register SourceReg = SecondPair->Source->getReg();
+      Register DestReg =   SecondPair->Destination->getReg();
+
+      // If register pair is valid and does not contain registers from first instruction.
+      if(isCandidateToMerge(*SecondPair) && (FirstPair.Source->getReg() != SourceReg) &&
+        (FirstPair.Destination->getReg() != DestReg)){
+        
+        //  If paired destination register was modified or used, there is no possibility 
+        //  of finding matching instruction so exit early.
+        if (!ModifiedRegUnits.available(DestReg) ||  !UsedRegUnits.available(DestReg))
+          return E;
+
+        if (ModifiedRegUnits.available(SourceReg))
+          return I;
+      }
+    }
+    // Update modified / used register units.
+    LiveRegUnits::accumulateUsedDefed(MI, ModifiedRegUnits, UsedRegUnits, TRI);
+  }
+  return E;
+}
+
+
+// Finds instructions, which could be represented as C.MV instructions and merged into C.MVA01S07.
+bool RISCVMoveOpt::MovOpt(MachineBasicBlock &MBB){
+  bool Modified = false;
+
+  for (MachineBasicBlock::iterator MBBI = MBB.begin(), E = MBB.end();
+         MBBI != E;) {
+    // Check if the instruction can be compressed to C.MV instruction. If it can, return Dest/Src 
+    // register pair.
+    auto RegPair = TII->getCMovReg(*MBBI);
+    if(RegPair.hasValue() && isCandidateToMerge(*RegPair)){
+      MachineBasicBlock::iterator Paired= findMatchingInst(MBBI);
+      //If matching instruction could be found merge them.
+      if(Paired != E){
+        MBBI= mergePairedInsns(MBBI, Paired);
+        Modified = true;
+        continue;
+      }
+    }
+    ++MBBI;
+  }
+  return Modified;
+}
+
+
+bool RISCVMoveOpt::runOnMachineFunction(MachineFunction &Fn) {
+  if (skipFunction(Fn.getFunction()))
+    return false;
+
+  Subtarget = &static_cast<const RISCVSubtarget &>(Fn.getSubtarget());
+  if(!Subtarget->hasStdExtZce()){
+    return false;
+  }
+    
+  TII = static_cast<const RISCVInstrInfo *>(Subtarget->getInstrInfo()); 
+  TRI = Subtarget->getRegisterInfo(); 
+  // Resize the modified and used register unit trackers.  We do this once
+  // per function and then clear the register units each time we optimize a 
+  // move.
+  ModifiedRegUnits.init(*TRI);
+  UsedRegUnits.init(*TRI);
+  bool Modified = false;
+  for (auto &MBB : Fn) {
+    Modified |= MovOpt(MBB);
+  }
+  return Modified;
+}
+
+/// createRISCVMoveOptimizationPass - returns an instance of the
+/// move optimization pass.
+FunctionPass *llvm::createRISCVMoveOptimizationPass() {
+  return new RISCVMoveOpt();
+}

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -32,6 +32,11 @@
 #include "llvm/Target/TargetOptions.h"
 using namespace llvm;
 
+static cl::opt<bool> EnableMovOpt("riscv-enable-mov-opt",
+                                        cl::desc("Enable the compressed move"
+                                                 " optimization pass"),
+                                        cl::init(true), cl::Hidden);
+
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeRISCVTarget() {
   RegisterTargetMachine<RISCVTargetMachine> X(getTheRISCV32Target());
   RegisterTargetMachine<RISCVTargetMachine> Y(getTheRISCV64Target());
@@ -40,6 +45,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeRISCVTarget() {
   initializeRISCVMergeBaseOffsetOptPass(*PR);
   initializeRISCVExpandPseudoPass(*PR);
   initializeRISCVCleanupVSETVLIPass(*PR);
+  initializeRISCVMoveOptPass(*PR);
 }
 
 static StringRef computeDataLayout(const Triple &TT) {
@@ -183,6 +189,8 @@ void RISCVPassConfig::addPreSched2() {}
 void RISCVPassConfig::addPreEmitPass() { addPass(&BranchRelaxationPassID); }
 
 void RISCVPassConfig::addPreEmitPass2() {
+  if(EnableMovOpt)
+    addPass(createRISCVMoveOptimizationPass());
   addPass(createRISCVExpandPseudoPass());
   // Schedule the expansion of AMOs at the last possible moment, avoiding the
   // possibility for other passes to break the requirements for forward

--- a/llvm/test/CodeGen/RISCV/c_mva01s07.ll
+++ b/llvm/test/CodeGen/RISCV/c_mva01s07.ll
@@ -1,0 +1,23 @@
+; RUN: llc -mtriple=riscv32 -mattr=+experimental-zce -verify-machineinstrs < %s \
+; RUN: | FileCheck %s -check-prefix=VALID
+; RUN: llc -mtriple=riscv64 -mattr=+experimental-zce -verify-machineinstrs < %s \
+; RUN: | FileCheck %s -check-prefix=VALID
+
+
+; Function Attrs: nounwind
+define dso_local i32 @cmva(i32 %num, i32 %f, i32 %d, i32 %dx) local_unnamed_addr #0 {
+ ;  VALID-LABEL: cmva:
+ ;  VALID: c.mva01s07 {{s[0-7]}}, {{s[0-7]}}
+ ;  VALID-NOT: c.mva01s07 {{a.}}, {{a.}}
+entry:
+  %mul = mul nsw i32 %dx, %d
+  %sub = sub nsw i32 %mul, %dx
+  %add = add nsw i32 %mul, %d
+  %mul2 = mul nsw i32 %sub, %dx
+  %add3 = add nsw i32 %add, %mul2
+  %mul4 = mul nsw i32 %add3, %d
+  %add6 = add nsw i32 %add3, %num
+  %add5 = add i32 %sub, %f
+  %add7 = add i32 %add5, %mul4
+  ret i32 %add7
+}


### PR DESCRIPTION
This pull request adds compiler support for generating RISCV_Zce C.MVA01S07 instruction using peephole optimization. This allows compiler to use the instruction when generating binaries. 