### PR TITLE
[BugFix] Corrected typo in CompressInstEmitter

### DIFF
--- a/llvm/utils/TableGen/RISCVCompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/RISCVCompressInstEmitter.cpp
@@ -791,7 +791,7 @@ void RISCVCompressInstEmitter::emitCompressInstEmitter(raw_ostream &o,
           CondStream.indent(6)
               << Namespace
               << "ValidateMachineOperand(MachineOperand::CreateImm("
-              << DestOperandMap[OpNo].Data.Imm << "), SubTarget, " << Entry
+              << DestOperandMap[OpNo].Data.Imm << "), Subtarget, " << Entry
               << ") &&\n";
         }
         if (CompressOrUncompress)


### PR DESCRIPTION
This commit fixes typo in CompressPat code generator implemented in
commit c1b0e66.