### PR TITLE
[ZCE][PushPop] update spimm field calculation and add testcases

### DIFF
--- a/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
+++ b/llvm/test/CodeGen/RISCV/callee-saved-gprs.ll
@@ -19,6 +19,10 @@
 ; RUN:   | FileCheck %s -check-prefix=RV64I
 ; RUN: llc -mtriple=riscv64 -verify-machineinstrs -frame-pointer=all < %s \
 ; RUN:   | FileCheck %s -check-prefix=RV64I-WITH-FP
+; RUN: llc -mtriple=riscv32 -mattr=+experimental-zcmp -verify-machineinstrs < %s \
+; RUN: | FileCheck %s -check-prefixes=RV32IZCMP
+; RUN: llc -mtriple=riscv64 -mattr=+experimental-zcmp -verify-machineinstrs < %s \
+; RUN: | FileCheck %s -check-prefixes=RV64IZCMP
 
 @var = global [32 x i32] zeroinitializer
 
@@ -249,6 +253,89 @@ define void @callee() nounwind {
 ; RV32I-WITH-FP-NEXT:    addi sp, sp, 80
 ; RV32I-WITH-FP-NEXT:    ret
 ;
+; RV32IZCMP-LABEL: callee:
+; RV32IZCMP:       # %bb.0:
+; RV32IZCMP-NEXT:    cm.push	{ra, s0-s11}, -80
+; RV32IZCMP-NEXT:    lui a7, %hi(var)
+; RV32IZCMP-NEXT:    lw a0, %lo(var)(a7)
+; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, %lo(var+4)(a7)
+; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, %lo(var+8)(a7)
+; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, %lo(var+12)(a7)
+; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    addi a5, a7, %lo(var)
+; RV32IZCMP-NEXT:    lw a0, 16(a5)
+; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 20(a5)
+; RV32IZCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw t4, 24(a5)
+; RV32IZCMP-NEXT:    lw t5, 28(a5)
+; RV32IZCMP-NEXT:    lw t6, 32(a5)
+; RV32IZCMP-NEXT:    lw s2, 36(a5)
+; RV32IZCMP-NEXT:    lw s3, 40(a5)
+; RV32IZCMP-NEXT:    lw s4, 44(a5)
+; RV32IZCMP-NEXT:    lw s5, 48(a5)
+; RV32IZCMP-NEXT:    lw s6, 52(a5)
+; RV32IZCMP-NEXT:    lw s7, 56(a5)
+; RV32IZCMP-NEXT:    lw s8, 60(a5)
+; RV32IZCMP-NEXT:    lw s9, 64(a5)
+; RV32IZCMP-NEXT:    lw s10, 68(a5)
+; RV32IZCMP-NEXT:    lw s11, 72(a5)
+; RV32IZCMP-NEXT:    lw ra, 76(a5)
+; RV32IZCMP-NEXT:    lw s1, 80(a5)
+; RV32IZCMP-NEXT:    lw t3, 84(a5)
+; RV32IZCMP-NEXT:    lw t2, 88(a5)
+; RV32IZCMP-NEXT:    lw t1, 92(a5)
+; RV32IZCMP-NEXT:    lw t0, 96(a5)
+; RV32IZCMP-NEXT:    lw s0, 100(a5)
+; RV32IZCMP-NEXT:    lw a6, 104(a5)
+; RV32IZCMP-NEXT:    lw a4, 108(a5)
+; RV32IZCMP-NEXT:    lw a0, 124(a5)
+; RV32IZCMP-NEXT:    lw a1, 120(a5)
+; RV32IZCMP-NEXT:    lw a2, 116(a5)
+; RV32IZCMP-NEXT:    lw a3, 112(a5)
+; RV32IZCMP-NEXT:    sw a0, 124(a5)
+; RV32IZCMP-NEXT:    sw a1, 120(a5)
+; RV32IZCMP-NEXT:    sw a2, 116(a5)
+; RV32IZCMP-NEXT:    sw a3, 112(a5)
+; RV32IZCMP-NEXT:    sw a4, 108(a5)
+; RV32IZCMP-NEXT:    sw a6, 104(a5)
+; RV32IZCMP-NEXT:    sw s0, 100(a5)
+; RV32IZCMP-NEXT:    sw t0, 96(a5)
+; RV32IZCMP-NEXT:    sw t1, 92(a5)
+; RV32IZCMP-NEXT:    sw t2, 88(a5)
+; RV32IZCMP-NEXT:    sw t3, 84(a5)
+; RV32IZCMP-NEXT:    sw s1, 80(a5)
+; RV32IZCMP-NEXT:    sw ra, 76(a5)
+; RV32IZCMP-NEXT:    sw s11, 72(a5)
+; RV32IZCMP-NEXT:    sw s10, 68(a5)
+; RV32IZCMP-NEXT:    sw s9, 64(a5)
+; RV32IZCMP-NEXT:    sw s8, 60(a5)
+; RV32IZCMP-NEXT:    sw s7, 56(a5)
+; RV32IZCMP-NEXT:    sw s6, 52(a5)
+; RV32IZCMP-NEXT:    sw s5, 48(a5)
+; RV32IZCMP-NEXT:    sw s4, 44(a5)
+; RV32IZCMP-NEXT:    sw s3, 40(a5)
+; RV32IZCMP-NEXT:    sw s2, 36(a5)
+; RV32IZCMP-NEXT:    sw t6, 32(a5)
+; RV32IZCMP-NEXT:    sw t5, 28(a5)
+; RV32IZCMP-NEXT:    sw t4, 24(a5)
+; RV32IZCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 20(a5)
+; RV32IZCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 16(a5)
+; RV32IZCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+12)(a7)
+; RV32IZCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+8)(a7)
+; RV32IZCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+4)(a7)
+; RV32IZCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var)(a7)
+; RV32IZCMP-NEXT:    cm.popret	{ra, s0-s11}, 80
+;
 ; RV64I-LABEL: callee:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addi sp, sp, -160
@@ -471,6 +558,89 @@ define void @callee() nounwind {
 ; RV64I-WITH-FP-NEXT:    ld s11, 56(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    addi sp, sp, 160
 ; RV64I-WITH-FP-NEXT:    ret
+;
+; RV64IZCMP-LABEL: callee:
+; RV64IZCMP:       # %bb.0:
+; RV64IZCMP-NEXT:    cm.push	{ra, s0-s11}, -160
+; RV64IZCMP-NEXT:    lui a7, %hi(var)
+; RV64IZCMP-NEXT:    lw a0, %lo(var)(a7)
+; RV64IZCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+4)(a7)
+; RV64IZCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+8)(a7)
+; RV64IZCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+12)(a7)
+; RV64IZCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    addi a5, a7, %lo(var)
+; RV64IZCMP-NEXT:    lw a0, 16(a5)
+; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 20(a5)
+; RV64IZCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw t4, 24(a5)
+; RV64IZCMP-NEXT:    lw t5, 28(a5)
+; RV64IZCMP-NEXT:    lw t6, 32(a5)
+; RV64IZCMP-NEXT:    lw s2, 36(a5)
+; RV64IZCMP-NEXT:    lw s3, 40(a5)
+; RV64IZCMP-NEXT:    lw s4, 44(a5)
+; RV64IZCMP-NEXT:    lw s5, 48(a5)
+; RV64IZCMP-NEXT:    lw s6, 52(a5)
+; RV64IZCMP-NEXT:    lw s7, 56(a5)
+; RV64IZCMP-NEXT:    lw s8, 60(a5)
+; RV64IZCMP-NEXT:    lw s9, 64(a5)
+; RV64IZCMP-NEXT:    lw s10, 68(a5)
+; RV64IZCMP-NEXT:    lw s11, 72(a5)
+; RV64IZCMP-NEXT:    lw ra, 76(a5)
+; RV64IZCMP-NEXT:    lw s1, 80(a5)
+; RV64IZCMP-NEXT:    lw t3, 84(a5)
+; RV64IZCMP-NEXT:    lw t2, 88(a5)
+; RV64IZCMP-NEXT:    lw t1, 92(a5)
+; RV64IZCMP-NEXT:    lw t0, 96(a5)
+; RV64IZCMP-NEXT:    lw s0, 100(a5)
+; RV64IZCMP-NEXT:    lw a6, 104(a5)
+; RV64IZCMP-NEXT:    lw a4, 108(a5)
+; RV64IZCMP-NEXT:    lw a0, 124(a5)
+; RV64IZCMP-NEXT:    lw a1, 120(a5)
+; RV64IZCMP-NEXT:    lw a2, 116(a5)
+; RV64IZCMP-NEXT:    lw a3, 112(a5)
+; RV64IZCMP-NEXT:    sw a0, 124(a5)
+; RV64IZCMP-NEXT:    sw a1, 120(a5)
+; RV64IZCMP-NEXT:    sw a2, 116(a5)
+; RV64IZCMP-NEXT:    sw a3, 112(a5)
+; RV64IZCMP-NEXT:    sw a4, 108(a5)
+; RV64IZCMP-NEXT:    sw a6, 104(a5)
+; RV64IZCMP-NEXT:    sw s0, 100(a5)
+; RV64IZCMP-NEXT:    sw t0, 96(a5)
+; RV64IZCMP-NEXT:    sw t1, 92(a5)
+; RV64IZCMP-NEXT:    sw t2, 88(a5)
+; RV64IZCMP-NEXT:    sw t3, 84(a5)
+; RV64IZCMP-NEXT:    sw s1, 80(a5)
+; RV64IZCMP-NEXT:    sw ra, 76(a5)
+; RV64IZCMP-NEXT:    sw s11, 72(a5)
+; RV64IZCMP-NEXT:    sw s10, 68(a5)
+; RV64IZCMP-NEXT:    sw s9, 64(a5)
+; RV64IZCMP-NEXT:    sw s8, 60(a5)
+; RV64IZCMP-NEXT:    sw s7, 56(a5)
+; RV64IZCMP-NEXT:    sw s6, 52(a5)
+; RV64IZCMP-NEXT:    sw s5, 48(a5)
+; RV64IZCMP-NEXT:    sw s4, 44(a5)
+; RV64IZCMP-NEXT:    sw s3, 40(a5)
+; RV64IZCMP-NEXT:    sw s2, 36(a5)
+; RV64IZCMP-NEXT:    sw t6, 32(a5)
+; RV64IZCMP-NEXT:    sw t5, 28(a5)
+; RV64IZCMP-NEXT:    sw t4, 24(a5)
+; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 20(a5)
+; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 16(a5)
+; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var+12)(a7)
+; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var+8)(a7)
+; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var+4)(a7)
+; RV64IZCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var)(a7)
+; RV64IZCMP-NEXT:    cm.popret	{ra, s0-s11}, 160
   %val = load [32 x i32], [32 x i32]* @var
   store volatile [32 x i32] %val, [32 x i32]* @var
   ret void
@@ -769,6 +939,124 @@ define void @caller() nounwind {
 ; RV32I-WITH-FP-NEXT:    addi sp, sp, 144
 ; RV32I-WITH-FP-NEXT:    ret
 ;
+; RV32IZCMP-LABEL: caller:
+; RV32IZCMP:       # %bb.0:
+; RV32IZCMP-NEXT:    cm.push	{ra, s0-s11}, -112
+; RV32IZCMP-NEXT:    addi	sp, sp, -32
+; RV32IZCMP-NEXT:    lui s0, %hi(var)
+; RV32IZCMP-NEXT:    lw a0, %lo(var)(s0)
+; RV32IZCMP-NEXT:    sw a0, 88(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, %lo(var+4)(s0)
+; RV32IZCMP-NEXT:    sw a0, 84(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, %lo(var+8)(s0)
+; RV32IZCMP-NEXT:    sw a0, 80(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, %lo(var+12)(s0)
+; RV32IZCMP-NEXT:    sw a0, 76(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    addi s1, s0, %lo(var)
+; RV32IZCMP-NEXT:    lw a0, 16(s1)
+; RV32IZCMP-NEXT:    sw a0, 72(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 20(s1)
+; RV32IZCMP-NEXT:    sw a0, 68(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 24(s1)
+; RV32IZCMP-NEXT:    sw a0, 64(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 28(s1)
+; RV32IZCMP-NEXT:    sw a0, 60(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 32(s1)
+; RV32IZCMP-NEXT:    sw a0, 56(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 36(s1)
+; RV32IZCMP-NEXT:    sw a0, 52(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 40(s1)
+; RV32IZCMP-NEXT:    sw a0, 48(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 44(s1)
+; RV32IZCMP-NEXT:    sw a0, 44(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 48(s1)
+; RV32IZCMP-NEXT:    sw a0, 40(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 52(s1)
+; RV32IZCMP-NEXT:    sw a0, 36(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 56(s1)
+; RV32IZCMP-NEXT:    sw a0, 32(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 60(s1)
+; RV32IZCMP-NEXT:    sw a0, 28(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 64(s1)
+; RV32IZCMP-NEXT:    sw a0, 24(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 68(s1)
+; RV32IZCMP-NEXT:    sw a0, 20(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 72(s1)
+; RV32IZCMP-NEXT:    sw a0, 16(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 76(s1)
+; RV32IZCMP-NEXT:    sw a0, 12(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 80(s1)
+; RV32IZCMP-NEXT:    sw a0, 8(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw a0, 84(s1)
+; RV32IZCMP-NEXT:    sw a0, 4(sp) # 4-byte Folded Spill
+; RV32IZCMP-NEXT:    lw s4, 88(s1)
+; RV32IZCMP-NEXT:    lw s5, 92(s1)
+; RV32IZCMP-NEXT:    lw s6, 96(s1)
+; RV32IZCMP-NEXT:    lw s7, 100(s1)
+; RV32IZCMP-NEXT:    lw s8, 104(s1)
+; RV32IZCMP-NEXT:    lw s9, 108(s1)
+; RV32IZCMP-NEXT:    lw s10, 112(s1)
+; RV32IZCMP-NEXT:    lw s11, 116(s1)
+; RV32IZCMP-NEXT:    lw s2, 120(s1)
+; RV32IZCMP-NEXT:    lw s3, 124(s1)
+; RV32IZCMP-NEXT:    call callee@plt
+; RV32IZCMP-NEXT:    sw s3, 124(s1)
+; RV32IZCMP-NEXT:    sw s2, 120(s1)
+; RV32IZCMP-NEXT:    sw s11, 116(s1)
+; RV32IZCMP-NEXT:    sw s10, 112(s1)
+; RV32IZCMP-NEXT:    sw s9, 108(s1)
+; RV32IZCMP-NEXT:    sw s8, 104(s1)
+; RV32IZCMP-NEXT:    sw s7, 100(s1)
+; RV32IZCMP-NEXT:    sw s6, 96(s1)
+; RV32IZCMP-NEXT:    sw s5, 92(s1)
+; RV32IZCMP-NEXT:    sw s4, 88(s1)
+; RV32IZCMP-NEXT:    lw a0, 4(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 84(s1)
+; RV32IZCMP-NEXT:    lw a0, 8(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 80(s1)
+; RV32IZCMP-NEXT:    lw a0, 12(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 76(s1)
+; RV32IZCMP-NEXT:    lw a0, 16(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 72(s1)
+; RV32IZCMP-NEXT:    lw a0, 20(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 68(s1)
+; RV32IZCMP-NEXT:    lw a0, 24(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 64(s1)
+; RV32IZCMP-NEXT:    lw a0, 28(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 60(s1)
+; RV32IZCMP-NEXT:    lw a0, 32(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 56(s1)
+; RV32IZCMP-NEXT:    lw a0, 36(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 52(s1)
+; RV32IZCMP-NEXT:    lw a0, 40(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 48(s1)
+; RV32IZCMP-NEXT:    lw a0, 44(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 44(s1)
+; RV32IZCMP-NEXT:    lw a0, 48(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 40(s1)
+; RV32IZCMP-NEXT:    lw a0, 52(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 36(s1)
+; RV32IZCMP-NEXT:    lw a0, 56(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 32(s1)
+; RV32IZCMP-NEXT:    lw a0, 60(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 28(s1)
+; RV32IZCMP-NEXT:    lw a0, 64(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 24(s1)
+; RV32IZCMP-NEXT:    lw a0, 68(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 20(s1)
+; RV32IZCMP-NEXT:    lw a0, 72(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, 16(s1)
+; RV32IZCMP-NEXT:    lw a0, 76(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+12)(s0)
+; RV32IZCMP-NEXT:    lw a0, 80(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+8)(s0)
+; RV32IZCMP-NEXT:    lw a0, 84(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var+4)(s0)
+; RV32IZCMP-NEXT:    lw a0, 88(sp) # 4-byte Folded Reload
+; RV32IZCMP-NEXT:    sw a0, %lo(var)(s0)
+; RV32IZCMP-NEXT:    addi	sp, sp, 32
+; RV32IZCMP-NEXT:    cm.popret	{ra, s0-s11}, 112
+;
 ; RV64I-LABEL: caller:
 ; RV64I:       # %bb.0:
 ; RV64I-NEXT:    addi sp, sp, -288
@@ -1057,7 +1345,124 @@ define void @caller() nounwind {
 ; RV64I-WITH-FP-NEXT:    ld s11, 184(sp) # 8-byte Folded Reload
 ; RV64I-WITH-FP-NEXT:    addi sp, sp, 288
 ; RV64I-WITH-FP-NEXT:    ret
-
+;
+; RV64IZCMP-LABEL: caller:
+; RV64IZCMP:       # %bb.0:
+; RV64IZCMP-NEXT:    cm.push	{ra, s0-s11}, -160
+; RV64IZCMP-NEXT:    addi	sp, sp, -128
+; RV64IZCMP-NEXT:    lui s0, %hi(var)
+; RV64IZCMP-NEXT:    lw a0, %lo(var)(s0)
+; RV64IZCMP-NEXT:    sd a0, 176(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+4)(s0)
+; RV64IZCMP-NEXT:    sd a0, 168(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+8)(s0)
+; RV64IZCMP-NEXT:    sd a0, 160(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, %lo(var+12)(s0)
+; RV64IZCMP-NEXT:    sd a0, 152(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    addi s1, s0, %lo(var)
+; RV64IZCMP-NEXT:    lw a0, 16(s1)
+; RV64IZCMP-NEXT:    sd a0, 144(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 20(s1)
+; RV64IZCMP-NEXT:    sd a0, 136(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 24(s1)
+; RV64IZCMP-NEXT:    sd a0, 128(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 28(s1)
+; RV64IZCMP-NEXT:    sd a0, 120(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 32(s1)
+; RV64IZCMP-NEXT:    sd a0, 112(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 36(s1)
+; RV64IZCMP-NEXT:    sd a0, 104(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 40(s1)
+; RV64IZCMP-NEXT:    sd a0, 96(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 44(s1)
+; RV64IZCMP-NEXT:    sd a0, 88(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 48(s1)
+; RV64IZCMP-NEXT:    sd a0, 80(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 52(s1)
+; RV64IZCMP-NEXT:    sd a0, 72(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 56(s1)
+; RV64IZCMP-NEXT:    sd a0, 64(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 60(s1)
+; RV64IZCMP-NEXT:    sd a0, 56(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 64(s1)
+; RV64IZCMP-NEXT:    sd a0, 48(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 68(s1)
+; RV64IZCMP-NEXT:    sd a0, 40(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 72(s1)
+; RV64IZCMP-NEXT:    sd a0, 32(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 76(s1)
+; RV64IZCMP-NEXT:    sd a0, 24(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 80(s1)
+; RV64IZCMP-NEXT:    sd a0, 16(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw a0, 84(s1)
+; RV64IZCMP-NEXT:    sd a0, 8(sp) # 8-byte Folded Spill
+; RV64IZCMP-NEXT:    lw s4, 88(s1)
+; RV64IZCMP-NEXT:    lw s5, 92(s1)
+; RV64IZCMP-NEXT:    lw s6, 96(s1)
+; RV64IZCMP-NEXT:    lw s7, 100(s1)
+; RV64IZCMP-NEXT:    lw s8, 104(s1)
+; RV64IZCMP-NEXT:    lw s9, 108(s1)
+; RV64IZCMP-NEXT:    lw s10, 112(s1)
+; RV64IZCMP-NEXT:    lw s11, 116(s1)
+; RV64IZCMP-NEXT:    lw s2, 120(s1)
+; RV64IZCMP-NEXT:    lw s3, 124(s1)
+; RV64IZCMP-NEXT:    call callee@plt
+; RV64IZCMP-NEXT:    sw s3, 124(s1)
+; RV64IZCMP-NEXT:    sw s2, 120(s1)
+; RV64IZCMP-NEXT:    sw s11, 116(s1)
+; RV64IZCMP-NEXT:    sw s10, 112(s1)
+; RV64IZCMP-NEXT:    sw s9, 108(s1)
+; RV64IZCMP-NEXT:    sw s8, 104(s1)
+; RV64IZCMP-NEXT:    sw s7, 100(s1)
+; RV64IZCMP-NEXT:    sw s6, 96(s1)
+; RV64IZCMP-NEXT:    sw s5, 92(s1)
+; RV64IZCMP-NEXT:    sw s4, 88(s1)
+; RV64IZCMP-NEXT:    ld a0, 8(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 84(s1)
+; RV64IZCMP-NEXT:    ld a0, 16(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 80(s1)
+; RV64IZCMP-NEXT:    ld a0, 24(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 76(s1)
+; RV64IZCMP-NEXT:    ld a0, 32(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 72(s1)
+; RV64IZCMP-NEXT:    ld a0, 40(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 68(s1)
+; RV64IZCMP-NEXT:    ld a0, 48(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 64(s1)
+; RV64IZCMP-NEXT:    ld a0, 56(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 60(s1)
+; RV64IZCMP-NEXT:    ld a0, 64(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 56(s1)
+; RV64IZCMP-NEXT:    ld a0, 72(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 52(s1)
+; RV64IZCMP-NEXT:    ld a0, 80(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 48(s1)
+; RV64IZCMP-NEXT:    ld a0, 88(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 44(s1)
+; RV64IZCMP-NEXT:    ld a0, 96(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 40(s1)
+; RV64IZCMP-NEXT:    ld a0, 104(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 36(s1)
+; RV64IZCMP-NEXT:    ld a0, 112(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 32(s1)
+; RV64IZCMP-NEXT:    ld a0, 120(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 28(s1)
+; RV64IZCMP-NEXT:    ld a0, 128(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 24(s1)
+; RV64IZCMP-NEXT:    ld a0, 136(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 20(s1)
+; RV64IZCMP-NEXT:    ld a0, 144(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, 16(s1)
+; RV64IZCMP-NEXT:    ld a0, 152(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var+12)(s0)
+; RV64IZCMP-NEXT:    ld a0, 160(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var+8)(s0)
+; RV64IZCMP-NEXT:    ld a0, 168(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var+4)(s0)
+; RV64IZCMP-NEXT:    ld a0, 176(sp) # 8-byte Folded Reload
+; RV64IZCMP-NEXT:    sw a0, %lo(var)(s0)
+; RV64IZCMP-NEXT:    addi sp, sp, 128
+; RV64IZCMP-NEXT:    cm.popret	{ra, s0-s11}, 160
   %val = load [32 x i32], [32 x i32]* @var
   call void @callee()
   store volatile [32 x i32] %val, [32 x i32]* @var

--- a/llvm/test/CodeGen/RISCV/rvZce/push-pop.ll
+++ b/llvm/test/CodeGen/RISCV/rvZce/push-pop.ll
@@ -1,0 +1,66 @@
+; NOTE: Check cm.push/cm.pop.
+; RUN: llc -mtriple=riscv32 -mattr=+experimental-zcmp -verify-machineinstrs < %s \
+; RUN: | FileCheck %s -check-prefixes=RV32IZCMP
+; RUN: llc -mtriple=riscv64 -mattr=+experimental-zcmp -verify-machineinstrs < %s \
+; RUN: | FileCheck %s -check-prefixes=RV64IZCMP
+; RUN: llc -mtriple=riscv32 -verify-machineinstrs < %s \
+; RUN: | FileCheck -check-prefixes=RV32I %s
+; RUN: llc -mtriple=riscv64 -verify-machineinstrs < %s \
+; RUN: | FileCheck -check-prefixes=RV64I %s
+
+declare void @test(i8*)
+
+; Function Attrs: optnone
+define i32 @foo() {
+; RV32IZCMP-LABEL: foo:
+; RV32IZCMP:     # %bb.0:
+; RV32IZCMP-NEXT:  cm.push	{ra}, -64
+; RV32IZCMP-NEXT:  .cfi_def_cfa_offset 528
+; RV32IZCMP-NEXT:  addi	sp, sp, -464
+; RV32IZCMP-NEXT:  .cfi_offset ra, -4
+; RV32IZCMP-NEXT:  addi	a0, sp, 12
+; RV32IZCMP-NEXT:  call	test@plt
+; RV32IZCMP-NEXT:  addi	sp, sp, 464
+; RV32IZCMP-NEXT:  cm.popretz	{ra}, 64
+;
+; RV64IZCMP-LABEL: foo:
+; RV64IZCMP:     # %bb.0:
+; RV64IZCMP-NEXT:  cm.push	{ra}, -64
+; RV64IZCMP-NEXT:  .cfi_def_cfa_offset 528
+; RV64IZCMP-NEXT:  addi	sp, sp, -464
+; RV64IZCMP-NEXT:  .cfi_offset ra, -8
+; RV64IZCMP-NEXT:  addi	a0, sp, 8
+; RV64IZCMP-NEXT:  call	test@plt
+; RV64IZCMP-NEXT:  addi	sp, sp, 464
+; RV64IZCMP-NEXT:  cm.popretz	{ra}, 64
+;
+; RV32I-LABEL: foo:
+; RV32I:     # %bb.0:
+; RV32I-NEXT:  addi	sp, sp, -528
+; RV32I-NEXT:  .cfi_def_cfa_offset 528
+; RV32I-NEXT:  sw	ra, 524(sp) # 4-byte Folded Spill
+; RV32I-NEXT:  .cfi_offset ra, -4
+; RV32I-NEXT:  addi	a0, sp, 12
+; RV32I-NEXT:  call	test@plt
+; RV32I-NEXT:  li	a0, 0
+; RV32I-NEXT:  lw	ra, 524(sp) # 4-byte Folded Reload
+; RV32I-NEXT:  addi	sp, sp, 528
+; RV32I-NEXT:  ret
+;
+; RV64I-LABEL: foo:
+; RV64I:     # %bb.0:
+; RV64I-NEXT:  addi	sp, sp, -528
+; RV64I-NEXT:  .cfi_def_cfa_offset 528
+; RV64I-NEXT:  sd	ra, 520(sp) # 8-byte Folded Spill
+; RV64I-NEXT:  .cfi_offset ra, -8
+; RV64I-NEXT:  addi	a0, sp, 8
+; RV64I-NEXT:  call	test@plt
+; RV64I-NEXT:  li	a0, 0
+; RV64I-NEXT:  ld	ra, 520(sp) # 8-byte Folded Reload
+; RV64I-NEXT:  addi	sp, sp, 528
+; RV64I-NEXT:  ret
+  %1 = alloca [512 x i8]
+  %2 = getelementptr [512 x i8], [512 x i8]* %1, i32 0, i32 0
+  call void @test(i8* %2)
+  ret i32 0
+}


### PR DESCRIPTION
Spimm calculation is not updated from spec 0.50, and thus it leads to crash when Spimm is legal for push but illegal for cm.push.

Reproduce:
`llc -mtriple=riscv32 -mattr=+experimental-zcmp testcase.ll`

testcase.ll
```ll
declare void @test(i8*)

; Function Attrs: optnone
define i32 @foo() {
  %1 = alloca [512 x i8]
  %2 = getelementptr [512 x i8], [512 x i8]* %1, i32 0, i32 0
  call void @test(i8* %2)
  ret i32 0
}
```

Fail output:
```
Incorrect spimm
UNREACHABLE executed at /home/linsinan/gnu/llvm-project/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp:201!
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
Stack dump:
0.      Program arguments: ./../llvm-project/build/bin/llc -mtriple=riscv32 -mattr=+experimental-zcmp push-pop/test-4.ll -o test-1-zcmp.s
1.      Running pass 'Function Pass Manager' on module 'push-pop/test-4.ll'.
2.      Running pass 'RISCV Assembly Printer' on function '@foo'

 #0 0x000055bd062f8b78 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) /home/linsinan/gnu/llvm-project/llvm/lib/Support/Unix/Signals.inc:565:0
 #1 0x000055bd062f8c2f PrintStackTraceSignalHandler(void*) /home/linsinan/gnu/llvm-project/llvm/lib/Support/Unix/Signals.inc:632:0
    ...
#26 0x00007fa38f297c87 __libc_start_main /build/glibc-uZu3wS/glibc-2.27/csu/../csu/libc-start.c:344:0
#27 0x000055bd044b8c6a _start (./../llvm-project/build/bin/llc+0x1499c6a)
Aborted
```

Output with RV32I:
```asm
# %bb.0:
	addi	sp, sp, -528
	.cfi_def_cfa_offset 528
	sw	ra, 524(sp)                     # 4-byte Folded Spill
	.cfi_offset ra, -4
	addi	a0, sp, 12
	call	test@plt
	li	a0, 0
	lw	ra, 524(sp)                     # 4-byte Folded Reload
	addi	sp, sp, 528
	ret
```

Output after my fix (RV32IZCMP):
```asm
# %bb.0:
	cm.push	{ra}, -64
	.cfi_def_cfa_offset 528
	addi	sp, sp, -464
	.cfi_offset ra, -4
	addi	a0, sp, 12
	call	test@plt
	addi	sp, sp, 464
	cm.popretz	{ra}, 64
```
